### PR TITLE
Use new `Yojson.Basic.t` type to avoid deprecation of `json`

### DIFF
--- a/json_decoder.opam
+++ b/json_decoder.opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {build}
   "alcotest" {with-test}
   "result"
-  "yojson"
+  "yojson" {>= "1.6.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/src/json_decoder.ml
+++ b/src/json_decoder.ml
@@ -26,7 +26,7 @@ module Results = struct
   let (<$>) f t = t >>| f
 end
 
-type value = Yojson.Basic.json
+type value = Yojson.Basic.t
 
 type 'a t =
   | Decoder of ( value -> ('a, string) Result.result )

--- a/src/json_decoder.mli
+++ b/src/json_decoder.mli
@@ -9,8 +9,8 @@ type value
 val value_of_string : string -> value
 val value_to_string : value -> string
 
-val value_of_yojson : Yojson.Basic.json -> value
-val value_to_yojson : value -> Yojson.Basic.json
+val value_of_yojson : Yojson.Basic.t -> value
+val value_to_yojson : value -> Yojson.Basic.t
 
 val decode : 'a t -> value -> ('a, string) Result.result
 val decode_string : 'a t -> string -> ('a, string) Result.result


### PR DESCRIPTION
In Yojson 2.0 the old type will be replaced but the new type already exists since Yojson 1.6.